### PR TITLE
Add support for EastRising (BuyDisplay) ER-OLEDM1602-4Y

### DIFF
--- a/Firmware/Src/lcd.h
+++ b/Firmware/Src/lcd.h
@@ -14,3 +14,28 @@ void lcd_position( uint8_t );
 void lcd_clear();
 void lcd_pulse();
 extern void lcd_delay( uint32_t delay );
+
+// Support for the ER-OLEDM1602-4Y OLED from Buydisplay.
+// In lieu of the LED on PB1, PB1 must be connected to
+// RESET. CS should be tied to ground.
+// Jumper settings: BS2 HIGH BS1 LOW BS0 HIGH
+//
+// Pin mapping:
+// VCC - 3.3V
+// RD - E
+// RW - R/W
+// DC - RS
+// RES - PB1
+// CS - GND
+// D7-D4 to D7-D4 straight.
+//
+// I placed an extra cap VCC-GND on the OLED board, this
+// might not be necessary.
+// Note that programming may fail if the display is connected
+// (unsure why)
+//
+// 3.3V current draw ~65mA continuous. Suggest maybe
+// substitute a different 3.3V regulator for more margin?
+
+// Define for ER-OLEDM1602-4Y, undef for WEH001602AGPP5N00001
+#define OLED_EASTRISING

--- a/Firmware/Src/main.c
+++ b/Firmware/Src/main.c
@@ -234,7 +234,9 @@ int main(void)
     if( hal_tick % IWDG_REFRESH_DELAY == 0 )
     {
       HAL_IWDG_Refresh( &hiwdg );
+#ifndef OLED_EASTRISING // Pin used for reset line
       HAL_GPIO_TogglePin( GPIOB, GPIO_PIN_1 ); //heartbeat just for fun
+#endif
     }
     
     if( tip_delay > 0 )


### PR DESCRIPTION
This is a small change but took a while of banging on it to get it to work.

The ER-OLEDM1602-4Y is much easier to acquire than the WinStar display in the US, and cheaper as well.

The required changes are:
- Repurpose the blinking LED pin for the `RESET` line to the display, as it does not seem to have a good POR circuit built in.
- Slightly different initialization sequence (`E` starts low, no command required to put it in 4-bit mode, can skip the multiple 0 writes.)
- Hack around the controller putting the second line at `0x20` instead of `0x40` (note: The display controller datasheet says it should be at `0x40` but I could only get it to work at `0x20`).

The display has three solder jumpers BS0-BS2, they should be HIGH LOW HIGH for 4-bit 6800 mode.

The wiring is as follows:

- `E` connects to the pin labeled `RD`
- `RS` connects to the pin labeled `DC`
- `PB1` connects to the pin labeled `RES`
- `CS` should be tied to ground
- `VCC` should be 3.3V
- The rest of the pins (`D4`-`D7`, `RW`, and `GND`) connect as normal.

Note also that this display appears to be upside-down relative to the Winstar and Adafruit ones.